### PR TITLE
adding numpy adapters

### DIFF
--- a/src/grepros/plugins/auto/postgres.py
+++ b/src/grepros/plugins/auto/postgres.py
@@ -27,6 +27,26 @@ from ... import rosapi
 from ... common import ConsolePrinter
 from . dbbase import DataSinkBase, quote
 
+import numpy
+from psycopg2.extensions import register_adapter, AsIs
+def addapt_numpy_uint32(numpy_uint32):
+    return AsIs(numpy_uint32)
+def addapt_numpy_float32(numpy_float32):
+    return AsIs(numpy_float32)
+def addapt_numpy_int32(numpy_int32):
+    return AsIs(numpy_int32)
+def addapt_numpy_uint64(numpy_uint64):
+    return AsIs(numpy_uint64)
+def addapt_numpy_float64(numpy_float64):
+    return AsIs(numpy_float64)
+def addapt_numpy_int64(numpy_int64):
+    return AsIs(numpy_int64)
+register_adapter(numpy.uint32, addapt_numpy_uint32)
+register_adapter(numpy.float32, addapt_numpy_float32)
+register_adapter(numpy.int32, addapt_numpy_int32)
+register_adapter(numpy.uint64, addapt_numpy_uint64)
+register_adapter(numpy.float64, addapt_numpy_float64)
+register_adapter(numpy.int64, addapt_numpy_int64)
 
 class PostgresSink(DataSinkBase):
     """

--- a/src/grepros/plugins/auto/postgres.py
+++ b/src/grepros/plugins/auto/postgres.py
@@ -6,9 +6,10 @@ Sink plugin for dumping messages to a Postgres database.
 This file is part of grepros - grep for ROS bag files and live topics.
 Released under the BSD License.
 
-@author      Erki Suurjaak
+@author      [Erki Suurjaak, Iftach Naftaly]
 @created     02.12.2021
 @modified    27.03.2023
+@modified    15.06.2023
 ------------------------------------------------------------------------------
 """
 ## @namespace grepros.plugins.auto.postgres


### PR DESCRIPTION
Hi,

When trying to write ros2 bag with custom messages to Postgres, I get the following error:

`psycopg2.ProgrammingError: can't adapt type 'numpy.uint32'`

I fixed it with the [`register_adapter`](https://www.psycopg.org/docs/extensions.html#psycopg2.extensions.register_adapter) function.
